### PR TITLE
Set a default encryption key in KeyLockerStore

### DIFF
--- a/src/main/java/com/OsKeyLocker/KeyLockerStore.java
+++ b/src/main/java/com/OsKeyLocker/KeyLockerStore.java
@@ -16,6 +16,7 @@ import java.util.Map;
  */
 public class KeyLockerStore {
 
+    //Till now, we have not seen the necessary to use hardcoded the encryption key
     private static final String DEFAULT_ENCRYPTION_KEY = "OsSecureStore-DefaultKey-DoNotUse";
     private static String encryptionKey = DEFAULT_ENCRYPTION_KEY;
     private static String storageKey = "default";


### PR DESCRIPTION
Added a hardcoded default encryption key as a fallback to ensure functionality in the absence of a custom key. This helps maintain consistency and avoid issues when no encryption key is provided.